### PR TITLE
ci: use `macos-15-intel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13 # Intel
+          - macos-15-intel # Intel
           - windows-latest
         arch:
           - 'x64'
@@ -34,7 +34,7 @@ jobs:
           - 'lts'
           - 'nightly'
         exclude:
-          - os: macos-13 # Intel
+          - os: macos-15-intel # Intel
             arch: x86
         include:
           # macos-latest -> Apple Silicon (Need julia >= v1.8)


### PR DESCRIPTION
> The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead